### PR TITLE
Auto Docker Image build and Publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,26 @@ jobs:
       - run: rustup show
       - run: rustup component add clippy
       - run: cargo clippy --all -- --deny warnings --allow clippy::unknown-clippy-lints
+
+  docker:
+    name: DockerImage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          context: ./
+          file: ./Dockerfile
+          tags: ghcr.io/${{ github.actor }}/united-flarmnet:latest
+          secrets: |
+            GIT_AUTH_TOKEN=${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -56,14 +57,12 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.MY_PAT }}
 
       - name: build and push
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
           context: ./
           file: ./Dockerfile
           tags: ghcr.io/${{ github.actor }}/united-flarmnet:latest
-          secrets: |
-            GIT_AUTH_TOKEN=${{ github.token }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:bullseye as build
+WORKDIR /tmp/
+RUN git clone https://github.com/Turbo87/united-flarmnet.git && cd united-flarmnet
+WORKDIR /tmp/united-flarmnet
+RUN cargo install --path . 
+
+FROM debian:bullseye-slim 
+COPY --from=build /usr/local/cargo/bin/united-flarmnet /usr/local/bin/united-flarmnet
+WORKDIR /data
+ENTRYPOINT /usr/local/bin/united-flarmnet

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:bullseye as build
-WORKDIR /tmp/
-RUN git clone https://github.com/Turbo87/united-flarmnet.git && cd united-flarmnet
 WORKDIR /tmp/united-flarmnet
+COPY . .
 RUN cargo install --path . 
 
 FROM debian:bullseye-slim 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ After the program has finished downloading and processing the data,
 a `united.fln` file.
 
 
+Docker
+------------------------------------------------------------------------------
+To build a docker image with a function united-flarmnet binary, use the
+following commands:
+
+```
+docker build . -t united-flarmnet
+docker run --mount type=bind,source=${PWD},target=/data -t united-flarmnet
+```
+This will create a `united.fln` in the current directory.
+
+
 License
 ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR creates a Dockerimage and publishes this to packages of the user:
Example:
https://github.com/lordfolken/united-flarmnet/pkgs/container/united-flarmnet

Note: 
  * This needs a PAT with package write access. 
  * It has to be added as a secret MY_PAT in the repository. 
  * The package has to be:
  ** Granted write access from the repo
  ** published as public to be available anonymously

The plan is to include the resulting docker container in xcsoar-data-mapgen.
It will then publish daily a new united-flarmnet file to the repository. 
https://github.com/XCSoar/xcsoar-data-content/issues/238