### PR TITLE
Add `rust-toolchain.toml` file

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,8 @@
         ":maintainLockFilesWeekly",
         ":prConcurrentLimitNone",
         ":prHourlyLimitNone",
-        ":semanticCommitsDisabled"
+        ":semanticCommitsDisabled",
+        "github>Turbo87/renovate-config//rust/updateToolchain"
     ],
     "packageRules": [
         {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.56.0"


### PR DESCRIPTION
see https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file

This should ensure that the Rust version that is used on CI is stable and not randomly updated outside of our control.