### PR TITLE
Inline unnecessary functions

### DIFF
--- a/src/flarmnet.rs
+++ b/src/flarmnet.rs
@@ -3,19 +3,14 @@ use reqwest_middleware::ClientWithMiddleware;
 
 #[instrument(skip(client))]
 pub async fn get_flarmnet_file(client: &ClientWithMiddleware) -> anyhow::Result<flarmnet::File> {
-    let content = download_flarmnet_file(client).await?;
-    let decoded_file = flarmnet::xcsoar::decode_file(&content)?;
-    Ok(to_file(decoded_file))
-}
-
-#[instrument(skip(client))]
-async fn download_flarmnet_file(client: &ClientWithMiddleware) -> anyhow::Result<String> {
-    info!("downloading FlarmNet file…");
+    info!("Downloading FlarmNet file…");
     let response = client
         .get("https://www.flarmnet.org/static/files/wfn/data.fln")
         .send()
         .await?;
-    Ok(response.text().await?)
+    let content = response.text().await?;
+    let decoded_file = flarmnet::xcsoar::decode_file(&content)?;
+    Ok(to_file(decoded_file))
 }
 
 fn to_file(decoded: DecodedFile) -> flarmnet::File {

--- a/src/ogn.rs
+++ b/src/ogn.rs
@@ -46,17 +46,12 @@ impl Device {
 
 #[instrument(skip(client))]
 pub async fn get_ddb(client: &ClientWithMiddleware) -> anyhow::Result<Vec<Device>> {
-    let content = download_ogn_ddb_data(client).await?;
-    let ogn_ddb: DeviceDatabase = serde_json::from_str(&content)?;
-    Ok(ogn_ddb.devices)
-}
-
-#[instrument(skip(client))]
-async fn download_ogn_ddb_data(client: &ClientWithMiddleware) -> anyhow::Result<String> {
-    info!("downloading OGN DDB…");
+    info!("Downloading OGN DDB…");
     let response = client
         .get("http://ddb.glidernet.org/download/?j=1&t=1")
         .send()
         .await?;
-    Ok(response.text().await?)
+    let content = response.text().await?;
+    let ogn_ddb: DeviceDatabase = serde_json::from_str(&content)?;
+    Ok(ogn_ddb.devices)
 }

--- a/src/weglide.rs
+++ b/src/weglide.rs
@@ -48,21 +48,17 @@ impl Device {
 
 #[instrument(skip(client))]
 pub async fn get_devices(client: &ClientWithMiddleware) -> anyhow::Result<Vec<Device>> {
-    let devices = download_devices(client).await?;
+    info!("Downloading WeGlide device data…");
+    let response = client
+        .get("https://api.weglide.org/v1/user/device")
+        .send()
+        .await?;
+
+    let devices: Vec<Device> = response.json().await?;
     debug!(devices = devices.len());
 
     let current_devices: Vec<_> = devices.into_iter().filter(|it| it.is_current()).collect();
     debug!(current_devices = current_devices.len());
 
     Ok(current_devices)
-}
-
-#[instrument(skip(client))]
-async fn download_devices(client: &ClientWithMiddleware) -> anyhow::Result<Vec<Device>> {
-    info!("Downloading WeGlide device data…");
-    let response = client
-        .get("https://api.weglide.org/v1/user/device")
-        .send()
-        .await?;
-    Ok(response.json().await?)
 }


### PR DESCRIPTION
Now that we use HTTP-level caching we no longer need these child functions.