### PR TITLE
CI: Simplify `CI` workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,41 +6,42 @@ on:
       - main
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup set profile minimal
-      - run: rustup show
-      - run: cargo check --all
+      - uses: actions/checkout@v3.0.2
+      - uses: Swatinem/rust-cache@v2.0.0
+      - run: cargo check --all-targets
+        env:
+          RUSTFLAGS: "-D warnings"
 
   tests:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup set profile minimal
-      - run: rustup show
-      - run: cargo test --all
+      - uses: actions/checkout@v3.0.2
+      - uses: Swatinem/rust-cache@v2.0.0
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup set profile minimal
-      - run: rustup show
+      - uses: actions/checkout@v3.0.2
       - run: rustup component add rustfmt
-      - run: cargo fmt --all -- --check
+      - uses: Swatinem/rust-cache@v2.0.0
+      - run: cargo fmt -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup set profile minimal
-      - run: rustup show
+      - uses: actions/checkout@v3.0.2
       - run: rustup component add clippy
-      - run: cargo clippy --all -- --deny warnings --allow unknown_lints
+      - uses: Swatinem/rust-cache@v2.0.0
+      - run: cargo clippy -- --deny warnings --allow unknown_lints


### PR DESCRIPTION
This is similar to the CI config used for https://github.com/Turbo87/segelflug-classifieds