### PR TITLE
Add WeGlide profile metadata to the JSON export

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,9 +97,10 @@ async fn main() -> anyhow::Result<()> {
         .collect();
 
     info!("sorting result…");
-    merged.sort_unstable_by_key(|a| u32::from_str_radix(&a.flarm_id, 16).unwrap());
+    merged.sort_unstable_by_key(|a| u32::from_str_radix(&a.record.flarm_id, 16).unwrap());
 
-    merged.iter_mut().for_each(|record| {
+    merged.iter_mut().for_each(|merged| {
+        let record = &mut merged.record;
         if record.airfield == record.registration {
             record.airfield = "".to_string();
         }
@@ -112,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
 
     let xcsoar_records = merged
         .iter()
-        .filter_map(sanitize_record_for_xcsoar)
+        .filter_map(|merged| sanitize_record_for_xcsoar(&merged.record))
         .collect();
     let xcsoar_file = ::flarmnet::File {
         version: flarmnet_file.version,
@@ -125,7 +126,10 @@ async fn main() -> anyhow::Result<()> {
     let lx_file = File::create(lx_path)?;
     let mut lx_writer = ::flarmnet::lx::Writer::new(BufWriter::new(lx_file));
 
-    let lx_records = merged.iter().filter_map(sanitize_record_for_lx).collect();
+    let lx_records = merged
+        .iter()
+        .filter_map(|merged| sanitize_record_for_lx(&merged.record))
+        .collect();
     let lx_file = ::flarmnet::File {
         version: flarmnet_file.version,
         records: lx_records,
@@ -137,7 +141,10 @@ async fn main() -> anyhow::Result<()> {
     let tdb_file = File::create(tdb_path)?;
     let mut tdb_writer = ::flarmnet::tdb::Writer::new(BufWriter::new(tdb_file));
 
-    let tdb_records = merged.iter().filter_map(sanitize_record_for_tdb).collect();
+    let tdb_records = merged
+        .iter()
+        .filter_map(|merged| sanitize_record_for_tdb(&merged.record))
+        .collect();
     let tdb_file = ::flarmnet::File {
         version: flarmnet_file.version,
         records: tdb_records,
@@ -149,18 +156,23 @@ async fn main() -> anyhow::Result<()> {
     let json_file = File::create(json_path)?;
     let json_records: Vec<_> = merged
         .iter()
-        .filter_map(SerializableRecord::from_record)
+        .filter_map(|merged| SerializableRecord::from_record(&merged.record, merged.user.as_ref()))
         .collect();
     serde_json::to_writer(BufWriter::new(json_file), &json_records)?;
 
     Ok(())
 }
 
+struct MergedRecord {
+    record: ::flarmnet::Record,
+    user: Option<weglide::UserRef>,
+}
+
 fn merge(
     flarmnet_record: Option<::flarmnet::Record>,
     ogn_device: Option<ogn::Device>,
     weglide_device: Option<weglide::Device>,
-) -> Option<::flarmnet::Record> {
+) -> Option<MergedRecord> {
     let mut merged = ogn_device.map(|it| it.into_flarmnet_record());
 
     merged = match (merged, flarmnet_record) {
@@ -187,11 +199,19 @@ fn merge(
 
     match (merged, weglide_device) {
         (None, None) => None,
-        (Some(merged), None) => Some(merged),
-        (None, Some(weglide_device)) => Some(weglide_device.into_flarmnet_record()),
+        (Some(record), None) => Some(MergedRecord { record, user: None }),
+        (None, Some(device)) => {
+            let user = Some(device.user.clone());
+            Some(MergedRecord {
+                record: device.into_flarmnet_record(),
+                user,
+            })
+        }
         (Some(mut merged), Some(device)) => {
+            let mut user = None;
             if merged.call_sign == device.competition_id.unwrap_or_default() {
-                merged.pilot_name = device.user.name;
+                merged.pilot_name = device.user.name.clone();
+                user = Some(device.user);
 
                 if merged.registration.is_empty() {
                     merged.registration = device.name.unwrap_or_default();
@@ -201,7 +221,113 @@ fn merge(
                     merged.plane_type = device.aircraft.map(|it| it.name).unwrap_or_default();
                 }
             }
-            Some(merged)
+            Some(MergedRecord {
+                record: merged,
+                user,
+            })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn export_weglide(user: Value, call_sign: Option<&str>) -> Value {
+        let device = serde_json::from_value(json!({
+            "id": "ABCDEF",
+            "name": "D-1234",
+            "competition_id": "XY",
+            "until": null,
+            "user": user,
+        }))
+        .unwrap();
+        let record = call_sign.map(|call_sign| ::flarmnet::Record {
+            flarm_id: "ABCDEF".into(),
+            pilot_name: "Existing pilot".into(),
+            airfield: String::new(),
+            plane_type: String::new(),
+            registration: "D-1234".into(),
+            call_sign: call_sign.into(),
+            frequency: String::new(),
+        });
+        let merged = merge(record, None, Some(device)).unwrap();
+        let record = SerializableRecord::from_record(&merged.record, merged.user.as_ref());
+        serde_json::to_value(record).unwrap()
+    }
+
+    #[test]
+    fn test_weglide_profile_fields() {
+        for call_sign in [None, Some("XY")] {
+            let exported = export_weglide(
+                json!({
+                    "id": 123,
+                    "name": "Pilot",
+                    "image": "123/profile/photo.jpg",
+                    "club": { "id": 456, "name": "Gliding Club" },
+                }),
+                call_sign,
+            );
+            assert_eq!(
+                exported,
+                json!({
+                    "flarm_id": "ABCDEF",
+                    "pilot_name": "Pilot",
+                    "registration": "D-1234",
+                    "call_sign": "XY",
+                    "image_url": "https://weglidefiles.b-cdn.net/123/profile/photo.jpg",
+                    "weglide_user_id": 123,
+                    "club_name": "Gliding Club",
+                    "weglide_club_id": 456,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_missing_weglide_profile_fields() {
+        for extra in [
+            json!({}),
+            json!({"image": null, "club": null}),
+            json!({"image": ""}),
+        ] {
+            let mut user = json!({ "id": 123, "name": "Pilot" });
+            user.as_object_mut()
+                .unwrap()
+                .extend(extra.as_object().unwrap().clone());
+            assert_eq!(
+                export_weglide(user, None),
+                json!({
+                    "flarm_id": "ABCDEF",
+                    "pilot_name": "Pilot",
+                    "registration": "D-1234",
+                    "call_sign": "XY",
+                    "weglide_user_id": 123,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_mismatched_weglide_profile_is_omitted() {
+        let exported = export_weglide(
+            json!({
+                "id": 123,
+                "name": "Pilot",
+                "image": "123/profile/photo.jpg",
+                "club": { "id": 456, "name": "Gliding Club" },
+            }),
+            Some("ZZ"),
+        );
+        assert_eq!(
+            exported,
+            json!({
+                "flarm_id": "ABCDEF",
+                "pilot_name": "Existing pilot",
+                "registration": "D-1234",
+                "call_sign": "ZZ",
+            })
+        );
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,5 @@
 use crate::sanitize::has_data;
+use crate::weglide::UserRef;
 use flarmnet::Record;
 use serde::Serialize;
 
@@ -21,13 +22,26 @@ pub struct SerializableRecord<'a> {
     call_sign: &'a str,
     #[serde(skip_serializing_if = "str::is_empty")]
     frequency: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    weglide_user_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    club_name: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    weglide_club_id: Option<u32>,
 }
 
 impl<'a> SerializableRecord<'a> {
-    pub fn from_record(record: &'a Record) -> Option<Self> {
+    pub fn from_record(record: &'a Record, user: Option<&'a UserRef>) -> Option<Self> {
         if record.flarm_id.is_empty() || !has_data(record) {
             return None;
         }
+
+        let image = user
+            .and_then(|user| user.image.as_deref())
+            .filter(|image| !image.is_empty());
+        let club = user.and_then(|user| user.club.as_ref());
 
         Some(Self {
             flarm_id: &record.flarm_id,
@@ -37,6 +51,12 @@ impl<'a> SerializableRecord<'a> {
             registration: &record.registration,
             call_sign: &record.call_sign,
             frequency: &record.frequency,
+            image_url: image.map(|image| format!("https://weglidefiles.b-cdn.net/{image}")),
+            weglide_user_id: user.map(|user| user.id),
+            club_name: club
+                .map(|club| club.name.as_str())
+                .filter(|name| !name.is_empty()),
+            weglide_club_id: club.map(|club| club.id),
         })
     }
 }
@@ -57,7 +77,7 @@ mod tests {
             frequency: "123.456".to_string(),
         };
 
-        insta::assert_json_snapshot!(SerializableRecord::from_record(&record), @r#"
+        insta::assert_json_snapshot!(SerializableRecord::from_record(&record, None), @r#"
         {
           "flarm_id": "ABCDEF",
           "pilot_name": "John Dö",
@@ -82,7 +102,7 @@ mod tests {
             frequency: "".to_string(),
         };
 
-        insta::assert_json_snapshot!(SerializableRecord::from_record(&record), @r#"
+        insta::assert_json_snapshot!(SerializableRecord::from_record(&record, None), @r#"
         {
           "flarm_id": "ABCDEF",
           "registration": "D-1234"
@@ -102,7 +122,7 @@ mod tests {
             frequency: "123.456".to_string(),
         };
 
-        assert!(SerializableRecord::from_record(&record).is_none());
+        assert!(SerializableRecord::from_record(&record, None).is_none());
     }
 
     #[test]
@@ -117,6 +137,6 @@ mod tests {
             frequency: "".to_string(),
         };
 
-        assert!(SerializableRecord::from_record(&record).is_none());
+        assert!(SerializableRecord::from_record(&record, None).is_none());
     }
 }

--- a/src/weglide.rs
+++ b/src/weglide.rs
@@ -26,8 +26,16 @@ pub struct AircraftRef {
     pub name: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UserRef {
+    pub id: u32,
+    pub name: String,
+    pub image: Option<String>,
+    pub club: Option<ClubRef>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ClubRef {
     pub id: u32,
     pub name: String,
 }


### PR DESCRIPTION
The JSON export includes `image_url`, `weglide_user_id`, `club_name`, and `weglide_club_id` from the matched WeGlide profile. Image paths expand to full CDN URLs, and unavailable values are omitted.

Profile metadata follows the existing pilot-name matching rule. The other export formats remain unchanged.