### PR TITLE
Fall back to cached OGN data

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -31,12 +31,24 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - name: Restore HTTP cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: http-cache.redb
+          key: united-flarmnet-http-v1-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: united-flarmnet-http-v1-
 
       - run: cargo build --release
 
       - run: target/release/united-flarmnet
         env:
           RUST_LOG: info
+
+      - name: Save HTTP cache
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: http-cache.redb
+          key: united-flarmnet-http-v1-${{ github.run_id }}-${{ github.run_attempt }}
 
       - run: node build-webpage.mjs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,7 @@ name = "united-flarmnet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "deunicode",
  "encoding_rs",
  "flarmnet",
@@ -1896,6 +1897,7 @@ dependencies = [
  "reqwest-tracing",
  "serde",
  "serde_json",
+ "tempfile",
  "time",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "=1.0.104"
+bytes = "=1.12.1"
 deunicode = "=1.6.2"
 encoding_rs = "=0.8.41"
 flarmnet = "=0.6.0"
@@ -29,3 +30,4 @@ tracing-subscriber = { version = "=0.3.23", features = ["env-filter"] }
 
 [dev-dependencies]
 insta = { version = "=1.48.0", features = ["json"] }
+tempfile = "=3.27.0"

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,0 +1,137 @@
+use anyhow::Context;
+use bytes::Bytes;
+use http_cache_reqwest::{CacheMode, HttpCacheOptions};
+use reqwest_middleware::ClientWithMiddleware;
+use std::sync::Arc;
+
+pub fn cache_options() -> HttpCacheOptions {
+    HttpCacheOptions {
+        response_cache_mode_fn: Some(Arc::new(|_, response| {
+            (200..300)
+                .contains(&response.status)
+                .then_some(CacheMode::ForceCache)
+        })),
+        ..Default::default()
+    }
+}
+
+pub async fn get_with_cache_fallback(
+    client: &ClientWithMiddleware,
+    name: &str,
+    url: &str,
+) -> anyhow::Result<Bytes> {
+    match get(client, url, CacheMode::Reload).await {
+        Ok(contents) => Ok(contents),
+        Err(download_error) => {
+            let contents = get(client, url, CacheMode::OnlyIfCached)
+                .await
+                .with_context(|| {
+                    format!("no cached {name} response after download failed: {download_error}")
+                })?;
+            warn!("{name} download failed, using cached response: {download_error}");
+            Ok(contents)
+        }
+    }
+}
+
+async fn get(
+    client: &ClientWithMiddleware,
+    url: &str,
+    cache_mode: CacheMode,
+) -> anyhow::Result<Bytes> {
+    let response = client.get(url).with_extension(cache_mode).send().await?;
+    let response = response.error_for_status()?;
+    Ok(response.bytes().await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http_cache_reqwest::{Cache, HttpCache, RedbManager};
+    use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::path::Path;
+    use std::thread;
+
+    fn spawn_server(responses: Vec<&'static str>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+
+        thread::spawn(move || {
+            for response in responses {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut request_start = [0];
+                stream.read_exact(&mut request_start).unwrap();
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+
+        format!("http://{address}/data")
+    }
+
+    fn test_client(cache_path: &Path) -> ClientWithMiddleware {
+        let manager = RedbManager::new(cache_path).unwrap();
+        ClientBuilder::new(reqwest::Client::new())
+            .with(Cache(HttpCache {
+                mode: CacheMode::Default,
+                manager,
+                options: cache_options(),
+            }))
+            .build()
+    }
+
+    #[tokio::test]
+    async fn downloads_current_response() {
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\ncurrent";
+        let url = spawn_server(vec![response]);
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache_path = cache_dir.path().join("http-cache.redb");
+        let client = test_client(&cache_path);
+
+        let contents = get_with_cache_fallback(&client, "test data", &url)
+            .await
+            .unwrap();
+
+        assert_eq!(contents, b"current".as_slice());
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_cached_response() {
+        let current = "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nCache-Control: no-store\r\nConnection: close\r\n\r\ncached";
+        let failure =
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        let url = spawn_server(vec![current, failure]);
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache_path = cache_dir.path().join("http-cache.redb");
+        let client = test_client(&cache_path);
+
+        get_with_cache_fallback(&client, "test data", &url)
+            .await
+            .unwrap();
+        drop(client);
+
+        let client = test_client(&cache_path);
+        let contents = get_with_cache_fallback(&client, "test data", &url)
+            .await
+            .unwrap();
+
+        assert_eq!(contents, b"cached".as_slice());
+    }
+
+    #[tokio::test]
+    async fn fails_without_cached_response() {
+        let failure =
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        let url = spawn_server(vec![failure]);
+        let cache_dir = tempfile::tempdir().unwrap();
+        let cache_path = cache_dir.path().join("http-cache.redb");
+        let client = test_client(&cache_path);
+
+        let error = get_with_cache_fallback(&client, "test data", &url)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("no cached test data response"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use crate::sanitize::{
     sanitize_record_for_lx, sanitize_record_for_tdb, sanitize_record_for_xcsoar,
 };
 use crate::serde::SerializableRecord;
-use http_cache_reqwest::{Cache, CacheMode, HttpCache, HttpCacheOptions, RedbManager};
+use http_cache_reqwest::{Cache, CacheMode, HttpCache, RedbManager};
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use reqwest_tracing::TracingMiddleware;
@@ -13,10 +13,11 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::PathBuf;
-use tokio::try_join;
+use tokio::join;
 use tracing_subscriber::fmt::Subscriber;
 use tracing_subscriber::EnvFilter;
 
+mod download;
 mod flarmnet;
 mod ogn;
 mod sanitize;
@@ -41,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
         .with(Cache(HttpCache {
             mode: CacheMode::Default,
             manager: cache_manager,
-            options: HttpCacheOptions::default(),
+            options: download::cache_options(),
         }))
         .build();
 
@@ -49,7 +50,9 @@ async fn main() -> anyhow::Result<()> {
     let ogn_fut = ogn::get_ddb(&client);
     let weglide_fut = weglide::get_devices(&client);
 
-    let (flarmnet_file, ogn_ddb_records) = try_join!(flarmnet_fut, ogn_fut)?;
+    let (flarmnet_file, ogn_ddb_records) = join!(flarmnet_fut, ogn_fut);
+    let flarmnet_file = flarmnet_file?;
+    let ogn_ddb_records = optional_ogn_records(ogn_ddb_records);
 
     let weglide_devices = match weglide_fut.await {
         Ok(devices) => devices,
@@ -164,6 +167,13 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn optional_ogn_records(result: anyhow::Result<Vec<ogn::Device>>) -> Vec<ogn::Device> {
+    result.unwrap_or_else(|error| {
+        warn!("failed to fetch OGN devices: {error}");
+        Vec::new()
+    })
+}
+
 struct MergedRecord {
     record: ::flarmnet::Record,
     user: Option<weglide::UserRef>,
@@ -233,7 +243,15 @@ fn merge(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
     use serde_json::{json, Value};
+
+    #[test]
+    fn test_missing_ogn_data_is_ignored() {
+        let records = optional_ogn_records(Err(anyhow!("OGN unavailable")));
+
+        assert!(records.is_empty());
+    }
 
     fn export_weglide(user: Value, call_sign: Option<&str>) -> Value {
         let device = serde_json::from_value(json!({

--- a/src/ogn.rs
+++ b/src/ogn.rs
@@ -1,5 +1,8 @@
+use crate::download;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::Deserialize;
+
+const DDB_URL: &str = "http://ddb.glidernet.org/download/?j=1&t=1";
 
 #[derive(Debug, Deserialize)]
 struct DeviceDatabase {
@@ -47,11 +50,7 @@ impl Device {
 #[instrument(skip(client))]
 pub async fn get_ddb(client: &ClientWithMiddleware) -> anyhow::Result<Vec<Device>> {
     info!("Downloading OGN DDB…");
-    let response = client
-        .get("http://ddb.glidernet.org/download/?j=1&t=1")
-        .send()
-        .await?;
-    let response = response.error_for_status()?;
-    let ogn_ddb: DeviceDatabase = response.json().await?;
+    let contents = download::get_with_cache_fallback(client, "OGN DDB", DDB_URL).await?;
+    let ogn_ddb: DeviceDatabase = serde_json::from_slice(&contents)?;
     Ok(ogn_ddb.devices)
 }


### PR DESCRIPTION
OGN download failures no longer prevent generating the United FlarmNet outputs. After the existing retries are exhausted, the downloader uses a cached response of any age when available, or continues without OGN enrichment when no usable cache exists.

The Run workflow persists `http-cache.redb` through the GitHub Actions cache so responses remain available across hosted runners.